### PR TITLE
update deprecated boost url

### DIFF
--- a/org.kde.peruse.json
+++ b/org.kde.peruse.json
@@ -145,13 +145,13 @@
                     "sources": [
                         {
                             "type": "archive",
-                            "url": "https://boostorg.jfrog.io/artifactory/main/release/1.86.0/source/boost_1_86_0.tar.bz2",
+                            "url": "https://archives.boost.io/release/1.86.0/source/boost_1_86_0.tar.bz2",
                             "sha256": "1bed88e40401b2cb7a1f76d4bab499e352fa4d0c5f31c0dbae64e24d34d7513b",
                             "x-checker-data": {
                                 "type": "anitya",
                                 "project-id": 6845,
                                 "stable-only": true,
-                                "url-template": "https://boostorg.jfrog.io/artifactory/main/release/$version/source/boost_${major}_${minor}_$patch.tar.bz2"
+                                "url-template": "https://archives.boost.io/release/$version/source/boost_${major}_${minor}_$patch.tar.bz2"
                             }
                         }
                     ]


### PR DESCRIPTION


Download repository url has moved

refer: https://lists.boost.org/Archives/boost/2024/05/256914.php
