### PR TITLE
Use openjpeg module from runtime

### DIFF
--- a/org.kde.peruse.json
+++ b/org.kde.peruse.json
@@ -268,28 +268,6 @@
                     ]
                 },
                 {
-                    "name": "openjpeg",
-                    "buildsystem": "cmake-ninja",
-                    "builddir": true,
-                    "cleanup": [
-                        "/bin",
-                        "/lib/openjpeg-*"
-                    ],
-                    "sources": [
-                        {
-                            "type": "archive",
-                            "url": "https://github.com/uclouvain/openjpeg/archive/v2.5.4.tar.gz",
-                            "sha256": "a695fbe19c0165f295a8531b1e4e855cd94d0875d2f88ec4b61080677e27188a",
-                            "x-checker-data": {
-                                "type": "anitya",
-                                "project-id": 2550,
-                                "stable-only": true,
-                                "url-template": "https://github.com/uclouvain/openjpeg/archive/v$version.tar.gz"
-                            }
-                        }
-                    ]
-                },
-                {
                     "name": "poppler-data",
                     "buildsystem": "cmake-ninja",
                     "builddir": true,


### PR DESCRIPTION
KDE runtime version 5.15-24.08 (based on the Freedesktop runtime version 24.08) appears to provide the **openjpeg** module.

In most cases, you don't need to build this module separately, unless your project requires a specific version or a custom configuration.

**Related manifest file**

https://gitlab.com/freedesktop-sdk/freedesktop-sdk/-/blob/release/24.08/elements/components/openjpeg.bst

Fixes: https://github.com/flathub/org.kde.peruse/issues/127